### PR TITLE
Add click_govuk_button helper

### DIFF
--- a/docs/click-govuk-button.md
+++ b/docs/click-govuk-button.md
@@ -1,0 +1,52 @@
+---
+title: Clicking buttons
+layout: sub-navigation
+order: 2
+---
+
+This helper is a drop-in replacement for the standard `click_button` helper which adds some additional usability and accessibility checks.
+
+As well as working with standard `<button>` elements, the helper should also be used for links that are styled as buttons.
+
+Use this within tests that fill in forms across multiple pages.
+
+Here’s a simple example:
+
+```ruby
+  scenario "Completing the form" do
+    visit "/"
+
+    click_govuk_button "Start now"
+
+    fill_in "Name", with: "Jane Smith"
+    click_govuk_button "Continue"
+
+    fill_in "Email address", with: "jane@example.com"
+    click_govuk_button "Continue"
+
+    expect(page).to have_content("Check your answers")
+  end
+```
+
+The helper will check that:
+
+* there aren’t 2 or more buttons with the same text
+* the button has the `govuk-button` class
+* that `data-module="govuk-button"` has been added
+* if the button is a link styled as button, that `draggable="false"` and `role="button"` have been added
+* the button is not disabled
+
+## Disabled buttons
+
+Disabled buttons are [strongly discouraged](https://design-system.service.gov.uk/components/button/#disabled-buttons) as they have poor contrast and can confuse some users.
+
+If you really need to use disabled buttons, or have some user research showing it makes your service easier to understand, you can use the helper to click these by adding `disabled: true`. Clicking disabled buttons will not submit a form.
+
+```ruby
+  scenario "Clicking a disabled button" do
+    visit('/')
+    click_govuk_button "Send application", disabled: true
+
+    expect(page.current_path).to eql("/")
+  end
+```

--- a/docs/click-govuk-link.md
+++ b/docs/click-govuk-link.md
@@ -32,4 +32,4 @@ The helper will check that:
 * the link text isn’t an ambiguous word like "Change"
 * the full link text is specified (including any visually-hidden text) rather than a partial match
 * if the link is set to open in a new tab, then the phrase "opens in new tab" is included within the link text
-* the link isn’t styled as a button
+* the link isn’t styled as a button (if it is, use [`click_govuk_button`](/click-govuk-button) instead).

--- a/docs/click-govuk-link.md
+++ b/docs/click-govuk-link.md
@@ -1,7 +1,7 @@
 ---
 title: Clicking links
 layout: sub-navigation
-order: 2
+order: 3
 ---
 
 This helper is a drop-in replacement for the standard `click_link` helper, which adds some additional usability and accessibility checks.

--- a/docs/fill_in_govuk_text_field.md
+++ b/docs/fill_in_govuk_text_field.md
@@ -1,7 +1,7 @@
 ---
 title: Fill in a text field
 layout: sub-navigation
-order: 3
+order: 4
 ---
 
 This helper is a drop-in replacement for the standard `fill_in` helper, which adds some additional usability and accessibility checks.

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -9,6 +9,7 @@ startButton:
 content: |
   ## Navigating
 
+  * [Clicking buttons](click-govuk-button)
   * [Clicking links](click-govuk-link)
 
   ## Expecting content

--- a/docs/summarise-errors.md
+++ b/docs/summarise-errors.md
@@ -1,7 +1,7 @@
 ---
 title: Error summaries
 layout: sub-navigation
-order: 4
+order: 5
 ---
 
 Use this helper to test that the [Error summary component](https://design-system.service.gov.uk/components/error-summary/) is visible on the page with the correct content.

--- a/docs/summarise-errors.md
+++ b/docs/summarise-errors.md
@@ -1,7 +1,7 @@
 ---
 title: Error summaries
 layout: sub-navigation
-order: 3
+order: 4
 ---
 
 Use this helper to test that the [Error summary component](https://design-system.service.gov.uk/components/error-summary/) is visible on the page with the correct content.

--- a/docs/summarise.md
+++ b/docs/summarise.md
@@ -1,7 +1,7 @@
 ---
 title: Summary lists
 layout: sub-navigation
-order: 4
+order: 5
 ---
 
 Use this helper to test that the [Summary list component](https://design-system.service.gov.uk/components/summary-list/) is visible on the page with the correct content, for example on a Check your answers page.

--- a/docs/summarise.md
+++ b/docs/summarise.md
@@ -1,7 +1,7 @@
 ---
 title: Summary lists
 layout: sub-navigation
-order: 5
+order: 6
 ---
 
 Use this helper to test that the [Summary list component](https://design-system.service.gov.uk/components/summary-list/) is visible on the page with the correct content, for example on a Check your answers page.

--- a/lib/click_govuk_button.rb
+++ b/lib/click_govuk_button.rb
@@ -1,42 +1,80 @@
+module GovukRSpecHelpers
+  class ClickButton
 
-def click_govuk_button(button_text)
+    attr_reader :page, :button_text
 
-  buttons = all('button', text: button_text, exact_text: true)
-
-  if buttons.empty?
-    buttons = all('a.govuk-button', text: button_text, exact_text: true)
-  end
-
-  if buttons.size == 0
-
-    buttons_without_exact_match = all('button', text: button_text)
-
-    if buttons_without_exact_match.size > 0
-      raise "Unable to find button \"#{button_text}\" but did find button with the text \"#{buttons_without_exact_match.first.text}\" - include the full button text including any visually-hidden text"
-    else
-      raise "Unable to find button \"#{button_text}\""
+    def initialize(page:, button_text:)
+      @page = page
+      @button_text = button_text
     end
-  elsif buttons.size > 1
-    raise "There are #{buttons.size} buttons with the text \"#{button_text}\" - buttons should be unique within a page"
+
+    def click
+      @buttons = page.all('button', text: button_text, exact_text: true)
+
+      if @buttons.empty?
+        @buttons = page.all('a.govuk-button', text: button_text, exact_text: true)
+      end
+
+      if @buttons.size == 0
+        check_for_inexact_match
+        raise "Unable to find button \"#{button_text}\""
+      end
+
+      check_that_button_text_is_unique_on_the_page
+
+      @button = @buttons.first
+
+      check_data_module_attribute_is_present
+      check_role_is_present_if_button_is_a_link
+      check_for_govuk_class
+
+      @button.click
+    end
+
+  private
+
+    def check_for_inexact_match
+      buttons_without_exact_match = page.all('button', text: button_text)
+
+      if buttons_without_exact_match.size > 0
+        raise "Unable to find button \"#{button_text}\" but did find button with the text \"#{buttons_without_exact_match.first.text}\" - include the full button text including any visually-hidden text"
+      end
+    end
+
+    def check_that_button_text_is_unique_on_the_page
+      if @buttons.size > 1
+        raise "There are #{@buttons.size} buttons with the text \"#{button_text}\" - buttons should be unique within a page"
+      end
+    end
+
+    def check_data_module_attribute_is_present
+      if @button["data-module"] != "govuk-button"
+        raise "Button is missing the data-module=\"govuk-button\" attribute"
+      end
+    end
+
+    def check_role_is_present_if_button_is_a_link
+      if @button.tag_name == 'a' && @button["role"] != "button"
+        raise "Button found, but `role=\"button\"` is missing, this is needed on links styled as buttons"
+      end
+    end
+
+    def check_for_govuk_class
+      button_classes = @button[:class].to_s.split(/\s/).collect(&:strip)
+      if button_classes.empty?
+        raise "Button is missing a class, should contain \"govuk-button\""
+      elsif !button_classes.include?('govuk-button')
+        raise "Button is missing the govuk-button class, contains #{button_classes.join(', ')}"
+      end
+    end
+
   end
 
-  button = buttons.first
-
-  button_classes = button[:class].to_s.split(/\s/).collect(&:strip)
-
-  if button["data-module"] != "govuk-button"
-    raise "Button is missing the data-module=\"govuk-button\" attribute"
+  def click_govuk_button(button_text)
+    ClickButton.new(page: page, button_text: button_text).click
   end
 
-  if button.tag_name == 'a' && button["role"] != "button"
-    raise "Button found, but `role=\"button\"` is missing, this is needed on links styled as buttons"
-  end
-
-  if button_classes.include?('govuk-button')
-    button.click
-  elsif button_classes.empty?
-    raise "Button is missing a class, should contain \"govuk-button\""
-  else
-    raise "Button is missing the govuk-button class, contains #{button_classes.join(', ')}"
+  RSpec.configure do |rspec|
+    rspec.include self
   end
 end

--- a/lib/click_govuk_button.rb
+++ b/lib/click_govuk_button.rb
@@ -31,7 +31,7 @@ module GovukRSpecHelpers
       check_if_button_is_disabled
       check_for_govuk_class
 
-      @button.click
+      @button.click unless disabled
     end
 
   private

--- a/lib/click_govuk_button.rb
+++ b/lib/click_govuk_button.rb
@@ -27,6 +27,7 @@ module GovukRSpecHelpers
 
       check_data_module_attribute_is_present
       check_role_is_present_if_button_is_a_link
+      check_button_is_not_draggable_if_button_is_a_link
       check_if_button_is_disabled
       check_for_govuk_class
 
@@ -58,6 +59,12 @@ module GovukRSpecHelpers
     def check_role_is_present_if_button_is_a_link
       if @button.tag_name == 'a' && @button["role"] != "button"
         raise "Button found, but `role=\"button\"` is missing, this is needed on links styled as buttons"
+      end
+    end
+
+    def check_button_is_not_draggable_if_button_is_a_link
+      if @button.tag_name == 'a' && @button["draggable"] != "false"
+        raise "Button found, but `draggable=\"false\"` is missing, this is needed on links styled as buttons"
       end
     end
 

--- a/lib/click_govuk_button.rb
+++ b/lib/click_govuk_button.rb
@@ -1,0 +1,38 @@
+
+def click_govuk_button(button_text)
+
+  buttons = all('button', text: button_text, exact_text: true)
+
+  if buttons.empty?
+    buttons = all('a.govuk-button', text: button_text, exact_text: true)
+  end
+
+  if buttons.size == 0
+
+    buttons_without_exact_match = all('button', text: button_text)
+
+    if buttons_without_exact_match.size > 0
+      raise "Unable to find button \"#{button_text}\" but did find button with the text \"#{buttons_without_exact_match.first.text}\" - include the full button text including any visually-hidden text"
+    else
+      raise "Unable to find button \"#{button_text}\""
+    end
+  elsif buttons.size > 1
+    raise "There are #{buttons.size} buttons with the text \"#{button_text}\" - buttons should be unique within a page"
+  end
+
+  button = buttons.first
+
+  button_classes = button[:class].to_s.split(/\s/).collect(&:strip)
+
+  if button["data-module"] != "govuk-button"
+    raise "Button is missing the data-module=\"govuk-button\" attribute"
+  end
+
+  if button_classes.include?('govuk-button')
+    button.click
+  elsif button_classes.empty?
+    raise "Button is missing a class, should contain \"govuk-button\""
+  else
+    raise "Button is missing the govuk-button class, contains #{button_classes.join(', ')}"
+  end
+end

--- a/lib/click_govuk_button.rb
+++ b/lib/click_govuk_button.rb
@@ -28,6 +28,10 @@ def click_govuk_button(button_text)
     raise "Button is missing the data-module=\"govuk-button\" attribute"
   end
 
+  if button.tag_name == 'a' && button["role"] != "button"
+    raise "Button found, but `role=\"button\"` is missing, this is needed on links styled as buttons"
+  end
+
   if button_classes.include?('govuk-button')
     button.click
   elsif button_classes.empty?

--- a/lib/govuk_rspec_helpers.rb
+++ b/lib/govuk_rspec_helpers.rb
@@ -6,3 +6,4 @@ require_relative 'summarise_errors_matcher'
 require_relative 'summarise_matcher'
 
 require_relative 'click_govuk_link'
+require_relative 'click_govuk_button'

--- a/spec/click_govuk_button_spec.rb
+++ b/spec/click_govuk_button_spec.rb
@@ -162,9 +162,9 @@ RSpec.describe "click_govuk_button", type: :feature do
     end
 
     context "and disabled was specified" do
-      it 'should follow the link' do
+      it 'should not follow the link' do
         click_govuk_button('Submit', disabled: true)
-        expect(page.current_path).to eql("/success")
+        expect(page.current_path).to eql("/")
       end
     end
   end

--- a/spec/click_govuk_button_spec.rb
+++ b/spec/click_govuk_button_spec.rb
@@ -132,5 +132,57 @@ RSpec.describe "click_govuk_button", type: :feature do
     end
   end
 
+  context "where the button is disabled" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button disabled="disabled" aria-disabled="true" class="govuk-button govuk-button--disabled" data-module="govuk-button">
+        Submit
+      </button></form>'
+      visit('/')
+    end
 
+    context "and disabled wasn’t specified" do
+      it 'should raise an error' do
+        expect {
+          click_govuk_button('Submit')
+        }.to raise_error('Button is disabled. Avoid using disabled buttons as they have poor contrast and can confuse users. If this is unavoidable, use click_govuk_button("Submit", disabled: true)')
+      end
+    end
+
+    context "and disabled was specified" do
+      it 'should follow the link' do
+        click_govuk_button('Submit', disabled: true)
+        expect(page.current_path).to eql("/success")
+      end
+    end
+  end
+
+  context "where the button is disabled but the modifier class is missing" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button disabled="disabled" aria-disabled="true" class="govuk-button" data-module="govuk-button">
+        Submit
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Submit', disabled: true)
+      }.to raise_error('Disabled button is missing the govuk-button--disabled class')
+    end
+  end
+
+  context "where the button is disabled but aria-disabled is missing" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button disabled="disabled" class="govuk-button govuk-button--disabled" data-module="govuk-button">
+        Submit
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Submit', disabled: true)
+      }.to raise_error('Disabled button is missing aria-disabled="true"')
+    end
+  end
 end

--- a/spec/click_govuk_button_spec.rb
+++ b/spec/click_govuk_button_spec.rb
@@ -117,6 +117,19 @@ RSpec.describe "click_govuk_button", type: :feature do
     end
   end
 
+  context "where a link is styled as a button but draggable=false is missing" do
+    before do
+      TestApp.body = '<a href="/success" class="govuk-button" data-module="govuk-button" role="button">Continue</a>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Continue')
+      }.to raise_error('Button found, but `draggable="false"` is missing, this is needed on links styled as buttons')
+    end
+  end
+
   context "where the button contains visually-hidden text, but this isn’t specified in the helper" do
     before do
       TestApp.body = '<form action="/success" method="post"><button class="govuk-button" data-module="govuk-button">

--- a/spec/click_govuk_button_spec.rb
+++ b/spec/click_govuk_button_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "click_govuk_button", type: :feature do
+
+  context "where there no button" do
+    before do
+      TestApp.body = ''
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Testing')
+      }.to raise_error('Unable to find button "Testing"')
+    end
+  end
+
+  context "where there is a button" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button class="govuk-button" data-module="govuk-button">
+      Continue
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should submit the form' do
+      click_govuk_button('Continue')
+      expect(page.current_path).to eql("/success")
+    end
+  end
+
+  context "where there are 2 buttons with the same text" do
+    before do
+      TestApp.body = '<button>Continue</button> <button>Continue</button>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Continue')
+      }.to raise_error('There are 2 buttons with the text "Continue" - buttons should be unique within a page')
+    end
+  end
+
+  context "where the button is missing a class" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button data-module="govuk-button">
+      Continue
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Continue')
+      }.to raise_error('Button is missing a class, should contain "govuk-button"')
+    end
+  end
+
+  context "where the button has classes but not a govuk-button class" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button class="btn btn-bold" data-module="govuk-button">
+      Continue
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Continue')
+      }.to raise_error('Button is missing the govuk-button class, contains btn, btn-bold')
+    end
+  end
+
+  context "where the button has the govuk-button class but not data-module=govuk-button" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button class="govuk-button">
+      Continue
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Continue')
+      }.to raise_error('Button is missing the data-module="govuk-button" attribute')
+    end
+  end
+
+  context "where a start button has all the right attributes" do
+    before do
+      TestApp.body = '<a href="/success" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+  Start now
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+  </svg></a> '
+      visit('/')
+    end
+
+    it 'should follow the link' do
+      click_govuk_button('Start now')
+      expect(page.current_path).to eql("/success")
+    end
+  end
+
+  context "where the button contains visually-hidden text, but this isn’t specified in the helper" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><button class="govuk-button" data-module="govuk-button">
+      Add <span class="govuk-visually-hidden">test</span>
+      </button></form>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Add')
+      }.to raise_error('Unable to find button "Add" but did find button with the text "Add test" - include the full button text including any visually-hidden text')
+    end
+  end
+
+
+end

--- a/spec/click_govuk_button_spec.rb
+++ b/spec/click_govuk_button_spec.rb
@@ -104,6 +104,19 @@ RSpec.describe "click_govuk_button", type: :feature do
     end
   end
 
+  context "where a link is styled as a button but role=button is missing" do
+    before do
+      TestApp.body = '<a href="/success" class="govuk-button" data-module="govuk-button">Continue</a>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        click_govuk_button('Continue')
+      }.to raise_error('Button found, but `role="button"` is missing, this is needed on links styled as buttons')
+    end
+  end
+
   context "where the button contains visually-hidden text, but this isn’t specified in the helper" do
     before do
       TestApp.body = '<form action="/success" method="post"><button class="govuk-button" data-module="govuk-button">


### PR DESCRIPTION
Following the `click_govuk_link` helper added in #6, this does the same but for buttons.

It will work with both actual `<button>`s, and with links styled as buttons – on the basis that the tests should reflect how the interfaces appears to users, rather than the underlying implementation.

The helper currently does these checks:

* full text of the button is specified, including any visually-hidden text
* the button text is unique within the page
* the `gov-button` class is added
* `data-module="govuk-button"` is added (this is used by javascript which adds some accessibility enhancements)
* if it’s a link styled as a button, then `role="button"` is present