### PR TITLE
Normalise whitespace on link finder

### DIFF
--- a/lib/click_govuk_link.rb
+++ b/lib/click_govuk_link.rb
@@ -4,7 +4,7 @@ def click_govuk_link(link_text)
 
   ambiguous_link_texts = ["Change", "Add", "Remove"]
 
-  links = all('a', text: link_text, exact_text: true)
+  links = all('a', text: link_text, exact_text: true, normalize_ws: true)
 
   if links.size == 0
     links_without_exact_match = all('a', text: link_text)


### PR DESCRIPTION
This is required when using capybara in a headless browser context - but doesn't seem to be otherwise.