### PR TITLE
Add support for input type=submit

### DIFF
--- a/lib/click_govuk_button.rb
+++ b/lib/click_govuk_button.rb
@@ -16,6 +16,10 @@ module GovukRSpecHelpers
         @buttons = page.all('a.govuk-button', text: button_text, exact_text: true)
       end
 
+      if @buttons.empty?
+        @buttons = page.all("input[type=submit][value=\"#{Capybara::Selector::CSS.escape(button_text)}\"]")
+      end
+
       if @buttons.size == 0
         check_for_inexact_match
         raise "Unable to find button \"#{button_text}\""

--- a/spec/click_govuk_button_spec.rb
+++ b/spec/click_govuk_button_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe "click_govuk_button", type: :feature do
     end
   end
 
+  context "where there is an input with type=submit" do
+    before do
+      TestApp.body = '<form action="/success" method="post"><input type="submit" class="govuk-button" data-module="govuk-button" value="Continue" /></form>'
+      visit('/')
+    end
+
+    it 'should submit the form' do
+      click_govuk_button('Continue')
+      expect(page.current_path).to eql("/success")
+    end
+  end
+
   context "where there are 2 buttons with the same text" do
     before do
       TestApp.body = '<button>Continue</button> <button>Continue</button>'


### PR DESCRIPTION
Whilst the `<button>` element is the preferred way to create buttons nowadays, `<input type="submit">` is still supported, including by `govuk-frontend`.

For this reason, we should continue to support it with the helper, to avoid throwing unnecessary errors.

Fixes #21