### PR TITLE
Add checkbox helpers

### DIFF
--- a/docs/checkboxes.md
+++ b/docs/checkboxes.md
@@ -1,0 +1,55 @@
+---
+title: Checkboxes
+layout: sub-navigation
+order: 3
+---
+
+These helpers are a drop-in replacements for the standard `check` and `uncheck` helpers which add some additional usability and accessibility checks.
+
+Here’s a basic example:
+
+```ruby
+scenario "Changing a checkbox answer" do
+  visit "/"
+
+  within_govuk_fieldset "Which types of waste do you transport?",
+    hint: "Select all that apply" do
+
+    uncheck_govuk_checkbox "Waste from mines or quarries"
+    check_govuk_checkbox "Waste from animal carcasses"
+  end
+
+  click_govuk_button "Continue"
+
+  expect(page).to have_content("Waste from animal carcasses")
+  expect(page).not_to have_content("Waste from mines or quarries")
+end
+```
+
+These helpers will check that:
+
+* there is a label with the given text
+* a checkbox input is correctly associated with that label using the `for` attribute
+* any hints are correctly associated with the checkbox inputs
+* the labels and inputs have the right classes from GOV.UK Design System
+* the checkbox was not already checked or unchecked
+
+## Hints
+
+If a checkbox has a hint, you can specify this to check that it is correctly associated with the field using `aria-describedby`:
+
+```ruby
+scenario "Checking a checkbox which has a hint" do
+  visit "/"
+
+  within_govuk_fieldset "What is your nationality?",
+    hint: "If you have dual nationality, select all options that are relevant to you." do
+
+    check_govuk_checkbox "British", hint: "including English, Scottish, Welsh and Northern Irish"
+  end
+
+  click_govuk_button "Continue"
+
+  expect(page).to have_content("British")
+end
+```

--- a/docs/choosing-radio-options.md
+++ b/docs/choosing-radio-options.md
@@ -1,7 +1,7 @@
 ---
 title: Radio options
 layout: sub-navigation
-order: 5
+order: 7
 ---
 
 This helper is a drop-in replacement for the standard `choose` helper which adds some additional usability and accessibility checks.

--- a/docs/click-govuk-link.md
+++ b/docs/click-govuk-link.md
@@ -1,7 +1,7 @@
 ---
 title: Links
 layout: sub-navigation
-order: 4
+order: 6
 ---
 
 This helper is a drop-in replacement for the standard `click_link` helper, which adds some additional usability and accessibility checks.

--- a/docs/fill_in_govuk_text_field.md
+++ b/docs/fill_in_govuk_text_field.md
@@ -1,7 +1,7 @@
 ---
 title: Text fields
 layout: sub-navigation
-order: 6
+order: 9
 ---
 
 This helper is a drop-in replacement for the standard `fill_in` helper, which adds some additional usability and accessibility checks.

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -15,6 +15,7 @@ startButton:
     <h2 class="govuk-heading-m govuk-!-font-size-27">Navigating and filling in forms</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link" href="click-govuk-button">Buttons</a></li>
+      <li><a class="govuk-link" href="checkboxes">Checkboxes</a></li>
       <li><a class="govuk-link" href="within-fieldsets">Fieldsets</a></li>
       <li><a class="govuk-link" href="click-govuk-link">Links</a></li>
       <li><a class="govuk-link" href="choosing-radio-options">Radio options</a></li>

--- a/docs/summarise-errors.md
+++ b/docs/summarise-errors.md
@@ -1,7 +1,7 @@
 ---
 title: Error summaries
 layout: sub-navigation
-order: 7
+order: 4
 ---
 
 Use this helper to test that the [error summary component](https://design-system.service.gov.uk/components/error-summary/) is visible on the page with the correct content.

--- a/docs/within-fieldsets.md
+++ b/docs/within-fieldsets.md
@@ -1,7 +1,7 @@
 ---
 title: Fieldsets
 layout: sub-navigation
-order: 3
+order: 5
 ---
 
 This helper is a drop-in replacement for the standard `within_fieldset` helper which adds some additional usability and accessibility checks.

--- a/lib/check_govuk_checkbox.rb
+++ b/lib/check_govuk_checkbox.rb
@@ -1,5 +1,5 @@
 module GovukRSpecHelpers
-  class CheckGovukCheckbox
+  class GovukCheckbox
 
     attr_reader :page, :label_text, :hint_text
 
@@ -9,7 +9,17 @@ module GovukRSpecHelpers
       @page = page
     end
 
-    def choose
+    def check
+      set_checked(true)
+    end
+
+    def uncheck
+      set_checked(false)
+    end
+
+    private
+
+    def set_checked(checked)
       labels = page.all('label', text: label_text, exact_text: true, normalize_ws: true)
 
       if labels.size == 0
@@ -46,11 +56,11 @@ module GovukRSpecHelpers
 
       check_for_hint if hint_text
       check_that_hint_is_associated_with_input if @hint
+      check_that_checkbox_not_checked if checked
+      check_that_checkbox_is_checked if !checked
 
       @label.click
     end
-
-    private
 
     def check_for_input_id_match
       inputs = page.all('input', id: label_text)
@@ -128,10 +138,26 @@ module GovukRSpecHelpers
       end
     end
 
+    def check_that_checkbox_not_checked
+      if @input[:checked]
+        raise "Found checkbox, but it was already checked"
+      end
+    end
+
+    def check_that_checkbox_is_checked
+      if !@input[:checked]
+        raise "Found checkbox, but it was already unchecked"
+      end
+    end
+
   end
 
   def check_govuk_checkbox(label_text, hint: nil)
-    CheckGovukCheckbox.new(page: page, label_text: label_text, hint_text: hint).choose
+    GovukCheckbox.new(page: page, label_text: label_text, hint_text: hint).check
+  end
+
+  def uncheck_govuk_checkbox(label_text, hint: nil)
+    GovukCheckbox.new(page: page, label_text: label_text, hint_text: hint).uncheck
   end
 
   RSpec.configure do |rspec|

--- a/lib/check_govuk_checkbox.rb
+++ b/lib/check_govuk_checkbox.rb
@@ -1,0 +1,141 @@
+module GovukRSpecHelpers
+  class CheckGovukCheckbox
+
+    attr_reader :page, :label_text, :hint_text
+
+    def initialize(page:, label_text:, hint_text:)
+      @label_text = label_text
+      @hint_text = hint_text
+      @page = page
+    end
+
+    def choose
+      labels = page.all('label', text: label_text, exact_text: true, normalize_ws: true)
+
+      if labels.size == 0
+        check_for_input_id_match
+
+        raise "Unable to find label with the text \"#{label_text}\""
+      elsif labels.size > 1
+        raise "Found #{labels.size} labels with the same text. Checkbox labels should be unique within a fieldset."
+      end
+
+      @label = labels.first
+
+      check_label_has_a_for_attribute
+
+      inputs_matching_label = page.all(id: @label[:for])
+
+      if inputs_matching_label.size == 1
+        @input = inputs_matching_label.first
+      elsif inputs_matching_label.size == 0
+        raise "Found the label but it is not associated with an checkbox, did not find a checkbox with the ID \"#{@label[:for]}\"."
+      else
+        raise "Found #{inputs_matching_label.size} elements with id=\"#{@label[:for]}\". IDs must be unique."
+      end
+
+      check_input_type_is_radio
+
+      check_label_classes
+      check_input_class
+
+      hints = @label.ancestor('.govuk-checkboxes__item')
+        .all('.govuk-hint', text: hint_text, exact_text: true, normalize_ws: true)
+
+      @hint = hints.first
+
+      check_for_hint if hint_text
+      check_that_hint_is_associated_with_input if @hint
+
+      @label.click
+    end
+
+    private
+
+    def check_for_input_id_match
+      inputs = page.all('input', id: label_text)
+
+      if inputs.size > 0
+
+        matching_labels = page.all("label[for=#{label_text}]")
+
+        if matching_labels.size > 0
+          raise "Use the full label text \"#{matching_labels.first.text}\" instead of the input ID"
+        end
+      end
+    end
+
+    def check_label_has_a_for_attribute
+      if !@label[:for]
+        raise 'Found the label but it is not associated with an checkbox, was missing a for="" attribute'
+      end
+    end
+
+    def check_input_type_is_radio
+      if @input[:type] == 'radio'
+        raise "Found the label, but it is associated with an input with type=\"#{@input[:type]}\" not a checkbox"
+      end
+    end
+
+    def check_label_classes
+      label_classes = @label[:class].to_s.split(/\s+/)
+
+      if !label_classes.include?('govuk-label') && !label_classes.include?('govuk-checkboxes__label')
+        raise "Found label but it is missing the govuk-label and govuk-checkboxes__label classes"
+      elsif !label_classes.include?('govuk-label')
+        raise "Found label but it is missing the govuk-label class"
+      elsif !label_classes.include?('govuk-checkboxes__label')
+        raise "Found label but it is missing the govuk-checkboxes__label class"
+      end
+    end
+
+    def check_input_class
+      input_classes = @input[:class].to_s.split(/\s+/)
+
+      if !input_classes.include?('govuk-checkboxes__input')
+        raise "Found checkbox but it is missing the govuk-checkboxes__input class"
+      end
+    end
+
+
+    def check_for_hint
+      if @hint.nil? || @hint.text != hint_text
+        other_hints = @label.ancestor('.govuk-checkboxes__item').all('.govuk-hint')
+
+        if other_hints.size > 0 && hint_text
+          raise "Found checkbox but could not find matching hint. Found the hint \"#{other_hints.first.text}\" instead"
+        end
+      end
+    end
+
+    def check_that_hint_is_associated_with_input
+      hint_id = @hint[:id]
+
+      if hint_id.to_s.strip == ""
+        if hint_text
+          raise "Found checkbox and hint, but the hint is not associated with the input using aria. And an ID to the hint and Add aria-describedby= to the input with that ID."
+        else
+          raise "Found checkbox, but also found a hint that is not associated with the input using aria. And an ID to the hint and Add aria-describedby= to the input with that ID."
+        end
+      end
+
+      if !@input["aria-describedby"].to_s.split(/\s+/).include?(hint_id)
+        if hint_text
+          raise "Found checkbox and hint, but the hint is not associated with the input using aria. Add aria-describedby=\"#{hint_id}\" to the input."
+        else
+          raise "Found checkbox, but also found a hint that is not associated with the input using aria. Add aria-describedby=\"#{hint_id}\" to the input."
+        end
+      end
+    end
+
+  end
+
+  def check_govuk_checkbox(label_text, hint: nil)
+    CheckGovukCheckbox.new(page: page, label_text: label_text, hint_text: hint).choose
+  end
+
+  RSpec.configure do |rspec|
+    rspec.include self
+  end
+
+end

--- a/lib/govuk_rspec_helpers.rb
+++ b/lib/govuk_rspec_helpers.rb
@@ -5,6 +5,7 @@ require 'capybara'
 require_relative 'summarise_errors_matcher'
 require_relative 'summarise_matcher'
 
+require_relative 'check_govuk_checkbox'
 require_relative 'click_govuk_link'
 require_relative 'click_govuk_button'
 require_relative 'fill_in_govuk_text_field'

--- a/spec/check_govuk_checkbox_spec.rb
+++ b/spec/check_govuk_checkbox_spec.rb
@@ -1,0 +1,384 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "checking a chekcbox", type: :feature do
+
+  context "where there are multiple checkboxes nested in a fieldset" do
+
+    before do
+       TestApp.body = '<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        Which types of waste do you transport?
+      </h1>
+    </legend>
+    <div id="waste-hint" class="govuk-hint">
+      Select all that apply.
+    </div>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+        <label class="govuk-label govuk-checkboxes__label" for="waste">
+          Waste from animal carcasses
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+        <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+          Waste from mines or quarries
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+        <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+          Farm or agricultural waste
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>'
+      visit('/')
+    end
+
+    context "and the full fieldset and label is specified" do
+      it 'should be successful' do
+        within_govuk_fieldset "Which types of waste do you transport?" do
+          check_govuk_checkbox "Waste from mines or quarries"
+        end
+
+        expect(page).to have_checked_field("Waste from mines or quarries")
+      end
+    end
+
+    context "and the input id is specified" do
+      it 'should raise an error' do
+        expect {
+          within_govuk_fieldset "Which types of waste do you transport?" do
+            check_govuk_checkbox "waste-2"
+          end
+        }.to raise_error('Use the full label text "Waste from mines or quarries" instead of the input ID')
+      end
+    end
+
+    context "and no matching label can be found" do
+      it 'should raise an error' do
+        expect {
+          within_govuk_fieldset "Which types of waste do you transport?" do
+          check_govuk_checkbox "Waste from household bins"
+          end
+        }.to raise_error('Unable to find label with the text "Waste from household bins"')
+      end
+    end
+
+
+  end
+
+  context "where the checkbox has an associated hint" do
+    before do
+      TestApp.body = '<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="nationality-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        What is your nationality?
+      </h1>
+    </legend>
+    <div id="nationality-hint" class="govuk-hint">
+      If you have dual nationality, select all options that are relevant to you.
+    </div>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="nationality" name="nationality" type="checkbox" value="british" aria-describedby="nationality-item-hint">
+        <label class="govuk-label govuk-checkboxes__label" for="nationality">
+          British
+        </label>
+        <div id="nationality-item-hint" class="govuk-hint govuk-checkboxes__hint">
+          including English, Scottish, Welsh and Northern Irish
+        </div>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="nationality-2" name="nationality" type="checkbox" value="irish">
+        <label class="govuk-label govuk-checkboxes__label" for="nationality-2">
+          Irish
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="nationality-3" name="nationality" type="checkbox" value="other">
+        <label class="govuk-label govuk-checkboxes__label" for="nationality-3">
+          Citizen of another country
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>'
+      visit '/'
+    end
+
+    context "and hint is not specified" do
+      it 'should be successful' do
+        within_govuk_fieldset "What is your nationality?" do
+          check_govuk_checkbox "British"
+        end
+
+        expect(page).to have_checked_field("British")
+      end
+    end
+
+    context "and the full label and hint are specified" do
+      it 'should be successful' do
+        within_govuk_fieldset "What is your nationality?" do
+          check_govuk_checkbox "British", hint: "including English, Scottish, Welsh and Northern Irish"
+        end
+
+        expect(page).to have_checked_field("British")
+      end
+    end
+
+    context "and the hint does not match" do
+      it 'should raise an error' do
+        expect {
+          within_govuk_fieldset "What is your nationality?" do
+            check_govuk_checkbox "British", hint: "or citizen of United Kingdom"
+          end
+        }.to raise_error('Found checkbox but could not find matching hint. Found the hint "including English, Scottish, Welsh and Northern Irish" instead')
+      end
+    end
+
+    context "and both the label and hint do not match" do
+      it 'should raise an error focused on the label' do
+        expect {
+          within_govuk_fieldset "What is your nationality?" do
+            check_govuk_checkbox "United Kingdom", hint: "or British"
+          end
+        }.to raise_error('Unable to find label with the text "United Kingdom"')
+      end
+    end
+
+  end
+
+  context "where the label has a 'for' attribute but no input matches" do
+    before do
+       TestApp.body = '
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="organisation-1" name="organisation" type="checkbox" value="DfT">
+        <label class="govuk-label govuk-checkboxes__label" for="organisation-2">
+          Department for Transport
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it "should raise an error" do
+      expect {
+        check_govuk_checkbox "Department for Transport"
+      }.to raise_error('Found the label but it is not associated with an checkbox, did not find a checkbox with the ID "organisation-2".')
+    end
+  end
+
+  context "where the label is missing a 'for' attribute" do
+    before do
+       TestApp.body = '
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="organisation-1" name="organisation" type="checkbox" value="DfT">
+        <label class="govuk-label govuk-checkboxes__label">
+          Department for Transport
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it "should raise an error" do
+      expect {
+        check_govuk_checkbox "Department for Transport"
+      }.to raise_error('Found the label but it is not associated with an checkbox, was missing a for="" attribute')
+    end
+  end
+
+  context "where the hint has no ID and is not associated with the input" do
+    before do
+      TestApp.body = '<div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="nationality" name="nationality" type="checkbox" value="british">
+        <label class="govuk-label govuk-checkboxes__label" for="nationality">
+          British
+        </label>
+        <div class="govuk-hint govuk-checkboxes__hint">
+          including English, Scottish, Welsh and Northern Irish
+        </div>
+      </div>'
+      visit '/'
+    end
+
+    context 'and the hint is specified' do
+      it "should raise an error" do
+        expect {
+          check_govuk_checkbox "British", hint: "including English, Scottish, Welsh and Northern Irish"
+        }.to raise_error('Found checkbox and hint, but the hint is not associated with the input using aria. And an ID to the hint and Add aria-describedby= to the input with that ID.')
+      end
+    end
+
+    context 'and the hint is not specified' do
+      it "should still raise an error" do
+        expect {
+          check_govuk_checkbox "British"
+        }.to raise_error('Found checkbox, but also found a hint that is not associated with the input using aria. And an ID to the hint and Add aria-describedby= to the input with that ID.')
+      end
+    end
+  end
+
+  context "where the hint has an ID but is not associated with the input" do
+    before do
+      TestApp.body = '<div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="nationality" name="nationality" type="checkbox" value="british">
+        <label class="govuk-label govuk-checkboxes__label" for="nationality">
+          British
+        </label>
+        <div id="nationality-item-hint" class="govuk-hint govuk-checkboxes__hint">
+          including English, Scottish, Welsh and Northern Irish
+        </div>
+      </div>'
+      visit '/'
+    end
+
+    context 'and the hint is specified' do
+      it "should raise an error" do
+        expect {
+          check_govuk_checkbox "British", hint: "including English, Scottish, Welsh and Northern Irish"
+        }.to raise_error('Found checkbox and hint, but the hint is not associated with the input using aria. Add aria-describedby="nationality-item-hint" to the input.')
+      end
+    end
+
+    context 'and the hint is not specified' do
+      it "should still raise an error" do
+        expect {
+          check_govuk_checkbox "British"
+        }.to raise_error('Found checkbox, but also found a hint that is not associated with the input using aria. Add aria-describedby="nationality-item-hint" to the input.')
+      end
+    end
+  end
+
+  context "where the label is missing both classes" do
+    before do
+       TestApp.body = '
+        <input id="waste-3" name="waste" type="checkbox" value="farm">
+        <label for="waste-3">
+          Farm or agricultural waste
+        </label>
+        '
+      visit('/')
+    end
+
+    context "and the label text is specified" do
+      it "should raise an error" do
+        expect {
+          check_govuk_checkbox "Farm or agricultural waste"
+        }.to raise_error('Found label but it is missing the govuk-label and govuk-checkboxes__label classes')
+      end
+    end
+  end
+
+  context "where the label is missing the govuk-checkboxes__label class" do
+    before do
+       TestApp.body = '
+        <input id="waste-3" name="waste" type="checkbox" value="farm">
+        <label for="waste-3" class="govuk-label ">
+          Farm or agricultural waste
+        </label>
+        '
+      visit('/')
+    end
+
+    context "and the label text is specified" do
+      it "should raise an error" do
+        expect {
+          check_govuk_checkbox "Farm or agricultural waste"
+        }.to raise_error('Found label but it is missing the govuk-checkboxes__label class')
+      end
+    end
+  end
+
+  context "where the input is missing the govuk-checkboxes__input class" do
+    before do
+       TestApp.body = '
+        <input id="waste-3" name="waste" type="checkbox" value="farm">
+        <label for="waste-3" class="govuk-label govuk-checkboxes__label">
+          Farm or agricultural waste
+        </label>
+        '
+      visit('/')
+    end
+
+    context "and the label text is specified" do
+      it "should raise an error" do
+        expect {
+          check_govuk_checkbox "Farm or agricultural waste"
+        }.to raise_error('Found checkbox but it is missing the govuk-checkboxes__input class')
+      end
+    end
+
+  end
+
+  context "where there are 2 labels with the same text" do
+    before do
+       TestApp.body = '
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="organisation-1" name="organisation" type="checkbox" value="DfT">
+        <label class="govuk-label govuk-checkboxes__label" for="organisation-1">
+          Department for Transport
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="organisation-2" name="organisation" type="checkbox" value="DfT2">
+        <label class="govuk-label govuk-checkboxes__label" for="organisation-2">
+          Department for Transport
+        </label>
+      </div>
+        '
+      visit('/')
+    end
+
+    it "should raise an error" do
+      expect {
+        check_govuk_checkbox "Department for Transport"
+      }.to raise_error('Found 2 labels with the same text. Checkbox labels should be unique within a fieldset.')
+    end
+
+  end
+
+  context "where the input is a radio instead" do
+    before do
+       TestApp.body = '<div class="govuk-checkboxes__item">
+        <input class="govuk-radios__input" id="whereDoYouLive" name="whereDoYouLive" type="radio" value="england">
+        <label class="govuk-label govuk-checkboxes__label" for="whereDoYouLive">
+          England
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it "should raise an error" do
+      expect {
+        check_govuk_checkbox "England"
+      }.to raise_error('Found the label, but it is associated with an input with type="radio" not a checkbox')
+    end
+
+  end
+
+  context "where there are 2 elements with a matching ID" do
+    before do
+       TestApp.body = '<div class="govuk-checkboxes__item" id="whereDoYouLive">
+        <input class="govuk-checkboxes__input" id="whereDoYouLive" name="whereDoYouLive" type="radio" value="england">
+        <label class="govuk-label govuk-checkboxes__label" for="whereDoYouLive">
+          England
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it "should raise an error" do
+      expect {
+        check_govuk_checkbox "England"
+      }.to raise_error('Found 2 elements with id="whereDoYouLive". IDs must be unique.')
+    end
+  end
+
+end

--- a/spec/check_govuk_checkbox_spec.rb
+++ b/spec/check_govuk_checkbox_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe "checking a chekcbox", type: :feature do
   context "where there are 2 elements with a matching ID" do
     before do
        TestApp.body = '<div class="govuk-checkboxes__item" id="whereDoYouLive">
-        <input class="govuk-checkboxes__input" id="whereDoYouLive" name="whereDoYouLive" type="radio" value="england">
+        <input class="govuk-checkboxes__input" id="whereDoYouLive" name="whereDoYouLive" type="checkbox" value="england">
         <label class="govuk-label govuk-checkboxes__label" for="whereDoYouLive">
           England
         </label>
@@ -378,6 +378,24 @@ RSpec.describe "checking a chekcbox", type: :feature do
       expect {
         check_govuk_checkbox "England"
       }.to raise_error('Found 2 elements with id="whereDoYouLive". IDs must be unique.')
+    end
+  end
+
+  context "where the checkbox is already checked" do
+    before do
+       TestApp.body = '<div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="whereDoYouLive" name="whereDoYouLive" type="checkbox" value="england" checked>
+        <label class="govuk-label govuk-checkboxes__label" for="whereDoYouLive">
+          England
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it "should raise an error" do
+      expect {
+        check_govuk_checkbox "England"
+      }.to raise_error('Found checkbox, but it was already checked')
     end
   end
 

--- a/spec/uncheck_govuk_checkbox_spec.rb
+++ b/spec/uncheck_govuk_checkbox_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "unchecking a chekcbox", type: :feature do
+
+  context "where a checkbox is already checked" do
+    before do
+       TestApp.body = '<div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines" checked>
+        <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+          Waste from mines or quarries
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it 'should be successful' do
+      uncheck_govuk_checkbox "Waste from mines or quarries"
+
+      expect(page).to have_unchecked_field("Waste from mines or quarries")
+    end
+  end
+
+  context "where a checkbox is was not previously checked" do
+    before do
+       TestApp.body = '<div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+        <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+          Waste from mines or quarries
+        </label>
+      </div>'
+      visit('/')
+    end
+
+    it 'should raise an error' do
+      expect {
+        uncheck_govuk_checkbox "Waste from mines or quarries"
+      }.to raise_error("Found checkbox, but it was already unchecked")
+    end
+  end
+
+end


### PR DESCRIPTION
This adds 2 checkbox helpers:

* `check_govuk_checkbox` 
* `uncheck_govuk_checkbox`

Both are drop-in replacements for `check` and `uncheck`, which means that can be find-and-replaced without introducing any failures (so long as there’s no accessibility bugs).