### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,17 @@
+name: Publish
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag
+        required: true
+jobs:
+  publish:
+    name: Publish to RubyGems.org and GitHub Packages
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Publish gem
+        uses: dawidd6/action-publish-gem@v1
+        with:
+          api_key: ${{ secrets.RUBYGEMS_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/node_modules
 docs/_site
+*.gem


### PR DESCRIPTION
The new publish action accepts a 'tag' argument and will build and publish that tag when called. It requires manual running for now.
