### PR TITLE
Add checkout, setup and gem install steps

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -10,6 +10,20 @@ jobs:
     name: Publish to RubyGems.org and GitHub Packages
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.4'
+
+      - name: Install gems
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+
       - name: Publish gem
         uses: dawidd6/action-publish-gem@v1
         with:


### PR DESCRIPTION
I thought these steps were handled by the action but they aren't.

Tested with an alpha `v0.2a` [release](https://rubygems.org/gems/govuk-rspec-helpers/versions/0.2a) and tag.