### PR TITLE
Update `govuk-eleventy-plugin` dependency

### DIFF
--- a/docs/eleventy.config.js
+++ b/docs/eleventy.config.js
@@ -3,8 +3,6 @@ const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
 module.exports = function(eleventyConfig) {
   // Register the plugin
   eleventyConfig.addPlugin(govukEleventyPlugin, {
-    brandColour: '#28a',
-    fontFamily: 'system-ui, sans-serif',
     icons: {
       mask: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-mask-icon.svg?raw=true',
       shortcut: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-favicon.ico',
@@ -16,12 +14,9 @@ module.exports = function(eleventyConfig) {
       url: 'https://x-govuk.github.io/#projects',
       name: 'X-GOVUK projects'
     },
-    url: process.env.GITHUB_ACTIONS
-      ? 'https://x-govuk.github.io/govuk-rspec-helpers/'
-      : '/',
+    url: process.env.GITHUB_ACTIONS && 'https://x-govuk.github.io/govuk-rspec-helpers/',
     header: {
-      organisationLogo: 'x-govuk',
-      organisationName: 'X-GOVUK',
+      logotype: 'x-govuk',
       productName: 'RSpec Helpers',
       search: {
         indexPath: '/search.json',
@@ -34,9 +29,6 @@ module.exports = function(eleventyConfig) {
       },
       copyright: {
         text: '© X-GOVUK'
-      },
-      meta: {
-        items: []
       }
     }
   })
@@ -52,8 +44,6 @@ module.exports = function(eleventyConfig) {
       // Use layouts from the plugin
       layouts: 'node_modules/@x-govuk/govuk-eleventy-plugin/layouts'
     },
-    pathPrefix: process.env.GITHUB_ACTIONS
-      ? '/govuk-rspec-helpers/'
-      : '/'
+    pathPrefix: process.env.GITHUB_ACTIONS && '/govuk-rspec-helpers/'
   }
 };

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -12,7 +12,7 @@ startButton:
 ---
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds-from-desktop">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Navigating and filling in forms</h2>
+    <h2 class="govuk-heading-m">Navigating and filling in forms</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link" href="click-govuk-button">Buttons</a></li>
       <li><a class="govuk-link" href="checkboxes">Checkboxes</a></li>
@@ -21,7 +21,7 @@ startButton:
       <li><a class="govuk-link" href="choosing-radio-options">Radio options</a></li>
       <li><a class="govuk-link" href="fill_in_govuk_text_field">Text fields</a></li>
     </ul>
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Expecting content</h2>
+    <h2 class="govuk-heading-m">Expecting content</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link" href="summarise-errors">Error summaries</a></li>
       <li><a class="govuk-link" href="summarise">Summary lists</a></li>
@@ -29,8 +29,8 @@ startButton:
   </section>
   <section class="govuk-grid-column-full">
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Contribute</h2>
+    <h2 class="govuk-heading-m">Contribute</h2>
     <p class="govuk-body">The project repository is public and we welcome contributions from anyone.</p>
-    <p class="govuk-body"><a class="govuk-link govuk-!-font-weight-bold" href="{{ pkg.repository.url | replace(".git", "") }}">View this project on GitHub</a></p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ pkg.repository.url | replace(".git", "") }}">View this project on GitHub</a></p>
   </section>
 </div>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",
-        "@x-govuk/govuk-eleventy-plugin": "^5.0.3"
+        "@x-govuk/govuk-eleventy-plugin": "^6.0.0"
       },
       "engines": {
         "node": "^18"
@@ -110,20 +110,6 @@
       "integrity": "sha512-4aKW5aIQDFed8xs1G1pWcEiFPcDSwZtA4IH1eERtoJ+Xy+/fsoe0pzbDmw84bHZ9ACny5jblENhfZhcCxklqQw==",
       "dependencies": {
         "dependency-graph": "^0.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/11ty"
-      }
-    },
-    "node_modules/@11ty/eleventy-plugin-rss": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
-      "integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "posthtml": "^0.16.6",
-        "posthtml-urls": "1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -443,6 +429,162 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz",
+      "integrity": "sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.1.tgz",
+      "integrity": "sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.1.tgz",
+      "integrity": "sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.1.tgz",
+      "integrity": "sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.1.tgz",
+      "integrity": "sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.1.tgz",
+      "integrity": "sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.1.tgz",
+      "integrity": "sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.1.tgz",
+      "integrity": "sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.1.tgz",
+      "integrity": "sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.1.tgz",
+      "integrity": "sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.1.tgz",
+      "integrity": "sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.1.tgz",
+      "integrity": "sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.1.tgz",
+      "integrity": "sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sindresorhus/slugify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
@@ -503,9 +645,9 @@
       "optional": true
     },
     "node_modules/@types/cors": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -553,15 +695,18 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
-      "optional": true
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.8",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+      "version": "6.9.11",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
       "optional": true
     },
     "node_modules/@types/resolve": {
@@ -570,38 +715,36 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
     },
     "node_modules/@x-govuk/govuk-eleventy-plugin": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-eleventy-plugin/-/govuk-eleventy-plugin-5.0.3.tgz",
-      "integrity": "sha512-TmRwiaDqLMvXPYKbTXILrwCogol8fXl1VhVHYesyACoxUCHJULPuXqd6QJUkDiwdH3k0AfumqqaTwdf31v7Y7g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-eleventy-plugin/-/govuk-eleventy-plugin-6.0.2.tgz",
+      "integrity": "sha512-iJdzfVMIllBmA6PuouHKITqkBVVNAdTBkRQPuDZWFyC3NLua3/8PULxFjD2PG4UJlecQ4sDRefY/nuO4YFbDSQ==",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",
-        "@11ty/eleventy-plugin-rss": "^1.1.2",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
-        "@x-govuk/govuk-prototype-components": "^2.0.0",
+        "@x-govuk/govuk-prototype-components": "^3.0.0",
         "deepmerge": "^4.2.2",
-        "govuk-frontend": "^4.3.0",
+        "govuk-frontend": "^5.0.0",
         "luxon": "^3.0.1",
-        "markdown-it-abbr": "^1.0.4",
+        "markdown-it-abbr": "^2.0.0",
         "markdown-it-anchor": "^8.4.1",
-        "markdown-it-deflist": "^2.1.0",
-        "markdown-it-footnote": "^3.0.3",
-        "markdown-it-govuk": "^0.1.0",
+        "markdown-it-deflist": "^3.0.0",
+        "markdown-it-footnote": "^4.0.0",
+        "markdown-it-govuk": "^0.3.0",
         "markdown-it-image-figures": "^2.0.0",
-        "markdown-it-ins": "^3.0.1",
-        "markdown-it-mark": "^3.0.1",
-        "markdown-it-sub": "^1.0.0",
-        "markdown-it-sup": "^1.0.0",
+        "markdown-it-ins": "^4.0.0",
+        "markdown-it-mark": "^4.0.0",
+        "markdown-it-sub": "^2.0.0",
+        "markdown-it-sup": "^2.0.0",
         "markdown-it-table-of-contents": "^0.6.0",
         "rimraf": "^5.0.0",
-        "rollup": "^3.9.0",
+        "rollup": "^4.1.0",
         "sass": "^1.45.1",
         "smartypants": "^0.2.0"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/@x-govuk/govuk-eleventy-plugin/node_modules/brace-expansion": {
@@ -672,22 +815,50 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@x-govuk/govuk-eleventy-plugin/node_modules/rollup": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.1.tgz",
+      "integrity": "sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.9.1",
+        "@rollup/rollup-android-arm64": "4.9.1",
+        "@rollup/rollup-darwin-arm64": "4.9.1",
+        "@rollup/rollup-darwin-x64": "4.9.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.1",
+        "@rollup/rollup-linux-arm64-musl": "4.9.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-musl": "4.9.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.1",
+        "@rollup/rollup-win32-x64-msvc": "4.9.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/@x-govuk/govuk-prototype-components": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-2.0.2.tgz",
-      "integrity": "sha512-dOwdnTfLt2pRE6x4uvDvZ6ELYNZs+RHdlqqu8USftjX1wbcF/1oxkfEMD9A8b8E9fafGoc6M+Uhuo+mMO2/qjw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-3.0.0.tgz",
+      "integrity": "sha512-rv8HLEc7R4ExZnHwrMC+vopNYlj2x52/ck26sBFI9ovtjd2Us3PwrcYyXQZLPXk0lVdz7HIzz22eVPO6ZsSUfA==",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
         "eventslibjs": "^1.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "govuk-prototype-kit": "^13.0.1"
+        "govuk-prototype-kit": "^13.14.1"
       },
       "peerDependencies": {
-        "govuk-frontend": "^4.1.0"
+        "govuk-frontend": "^5.0.0"
       }
     },
     "node_modules/a-sync-waterfall": {
@@ -1317,9 +1488,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "optional": true,
       "engines": {
         "node": ">=6"
@@ -1924,9 +2095,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
+      "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
       "optional": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -1945,9 +2116,9 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
-      "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
+      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
       "optional": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -2450,9 +2621,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -2528,9 +2699,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "optional": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2656,51 +2827,60 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
+      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
       "engines": {
         "node": ">= 4.2.0"
       }
     },
     "node_modules/govuk-prototype-kit": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-13.13.1.tgz",
-      "integrity": "sha512-N6N+nepRJUsZtt71/QcFCpSXqUdybQwqTOMRjy7zFafNlnWfUB4EY3uvNs0ph525HsuM08jWUnfr3vJzXafTvw==",
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-13.16.0.tgz",
+      "integrity": "sha512-S9oKOkHDJS3P987JnjFuKlEOzLPl0EuAFh2AoqoX/qsKxiJExzRRmQ/5xzzd16j8YRrSwem+mqSCvczhTYk3Jg==",
       "optional": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
-        "body-parser": "^1.20.1",
-        "browser-sync": "^2.27.11",
+        "body-parser": "^1.20.2",
+        "browser-sync": "^2.29.3",
         "chokidar": "^3.5.3",
         "cookie-parser": "^1.4.6",
         "cross-spawn": "^7.0.3",
-        "csrf-csrf": "^2.2.4",
+        "csrf-csrf": "^2.3.0",
         "del": "^6.1.1",
-        "dotenv": "^16.0.3",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
-        "fs-extra": "^11.1.0",
-        "govuk-frontend": "^4.5.0",
-        "inquirer": "^8.2.0",
+        "fs-extra": "^11.1.1",
+        "govuk-frontend": "4.7.0",
+        "inquirer": "^8.2.6",
         "lodash": "^4.17.21",
-        "marked": "^4.2.5",
+        "marked": "^4.3.0",
         "nodemon": "^3.0.1",
-        "nunjucks": "^3.2.3",
+        "nunjucks": "^3.2.4",
         "portscanner": "^2.2.0",
         "require-dir": "^1.2.0",
-        "sass": "^1.66.1",
+        "sass": "^1.69.5",
         "sync-request": "^6.1.0",
-        "tar-stream": "^3.1.2",
+        "tar-stream": "^3.1.6",
         "universal-analytics": "^0.5.3",
-        "uuid": "^9.0.0",
+        "uuid": "^9.0.1",
         "zlib": "^1.0.5"
       },
       "bin": {
         "govuk-prototype-kit": "bin/cli"
       },
       "engines": {
-        "node": "^16.x || >= 18.x"
+        "node": "^16.x || ^18.x || >= 20.x"
+      }
+    },
+    "node_modules/govuk-prototype-kit/node_modules/govuk-frontend": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.2.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -2803,9 +2983,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
-      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2929,9 +3109,9 @@
       "optional": true
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "optional": true,
       "engines": {
         "node": ">= 4"
@@ -3546,9 +3726,9 @@
       }
     },
     "node_modules/markdown-it-abbr": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-abbr/-/markdown-it-abbr-1.0.4.tgz",
-      "integrity": "sha512-ZeA4Z4SaBbYysZap5iZcxKmlPL6bYA8grqhzJIHB1ikn7njnzaP8uwbtuXc4YXD5LicI4/2Xmc0VwmSiFV04gg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-abbr/-/markdown-it-abbr-2.0.0.tgz",
+      "integrity": "sha512-of7C8pXSjXjDojW4neNP+jD7inUYH/DO0Ca+K/4FUEccg0oHAEX/nfscw0jfz66PJbYWOAT9U8mjO21X5p6aAw=="
     },
     "node_modules/markdown-it-anchor": {
       "version": "8.6.7",
@@ -3560,24 +3740,24 @@
       }
     },
     "node_modules/markdown-it-deflist": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
-      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.0.tgz",
+      "integrity": "sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg=="
     },
     "node_modules/markdown-it-footnote": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
-      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ=="
     },
     "node_modules/markdown-it-govuk": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-govuk/-/markdown-it-govuk-0.1.3.tgz",
-      "integrity": "sha512-y+v3XjOE/+j6+P4lj4j8KPiAvUbpgl0Op8QWCEHIwGyx1tEBGKELh2v6KyPedrsz3VX+HESsX5wKMCjvs6k9zQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-govuk/-/markdown-it-govuk-0.3.0.tgz",
+      "integrity": "sha512-05061EM1oGxDfpLjwkvRKaNilXDV842Gd1cGOp8qz/ZSt4kSYHQ56Nb1io5rXPK730EH92dAdTosFTDo8cxTHQ==",
       "dependencies": {
         "highlight.js": "^11.5.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/markdown-it-image-figures": {
@@ -3592,24 +3772,24 @@
       }
     },
     "node_modules/markdown-it-ins": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-ins/-/markdown-it-ins-3.0.1.tgz",
-      "integrity": "sha512-32SSfZqSzqyAmmQ4SHvhxbFqSzPDqsZgMHDwxqPzp+v+t8RsmqsBZRG+RfRQskJko9PfKC2/oxyOs4Yg/CfiRw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-ins/-/markdown-it-ins-4.0.0.tgz",
+      "integrity": "sha512-sWbjK2DprrkINE4oYDhHdCijGT+MIDhEupjSHLXe5UXeVr5qmVxs/nTUVtgi0Oh/qtF+QKV0tNWDhQBEPxiMew=="
     },
     "node_modules/markdown-it-mark": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz",
-      "integrity": "sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-4.0.0.tgz",
+      "integrity": "sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg=="
     },
     "node_modules/markdown-it-sub": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz",
-      "integrity": "sha512-z2Rm/LzEE1wzwTSDrI+FlPEveAAbgdAdPhdWarq/ZGJrGW/uCQbKAnhoCsE4hAbc3SEym26+W2z/VQB0cQiA9Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-2.0.0.tgz",
+      "integrity": "sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA=="
     },
     "node_modules/markdown-it-sup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz",
-      "integrity": "sha512-E32m0nV9iyhRR7CrhnzL5msqic7rL1juWre6TQNxsnApg7Uf+F97JOKxUijg5YwXz86lZ0mqfOnutoryyNdntQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-2.0.0.tgz",
+      "integrity": "sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA=="
     },
     "node_modules/markdown-it-table-of-contents": {
       "version": "0.6.0",
@@ -3876,13 +4056,13 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nodemon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
-      "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
+      "integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
       "optional": true,
       "dependencies": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",
@@ -3901,15 +4081,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {
@@ -3997,9 +4168,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4679,6 +4850,8 @@
       "version": "3.28.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
       "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4763,9 +4936,9 @@
       "optional": true
     },
     "node_modules/sass": {
-      "version": "1.66.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
-      "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
+      "version": "1.69.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+      "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -5245,9 +5418,9 @@
       "optional": true
     },
     "node_modules/streamx": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
-      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
       "optional": true,
       "dependencies": {
         "fast-fifo": "^1.1.0",
@@ -5515,9 +5688,9 @@
       "optional": true
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
-      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
+      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5526,6 +5699,10 @@
         {
           "type": "paypal",
           "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
         }
       ],
       "optional": true,
@@ -5568,6 +5745,12 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "optional": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "optional": true
+    },
     "node_modules/universal-analytics": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.5.3.tgz",
@@ -5591,9 +5774,9 @@
       }
     },
     "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "optional": true,
       "engines": {
         "node": ">= 10.0.0"
@@ -5623,9 +5806,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^2.0.1",
-    "@x-govuk/govuk-eleventy-plugin": "^5.0.3"
+    "@x-govuk/govuk-eleventy-plugin": "^6.0.0"
   },
   "engines": {
     "node": "^18"

--- a/docs/sass/_settings.scss
+++ b/docs/sass/_settings.scss
@@ -1,0 +1,5 @@
+$govuk-font-family: system-ui, sans-serif;
+$govuk-brand-colour: #2288aa;
+$govuk-link-colour: #006688;
+$govuk-hover-colour: #004466;
+$govuk-visited-colour: #333366;


### PR DESCRIPTION
Updates `govuk-eleventy-plugin` dependency to the new v6.0.0 and copies across tiny design changes used across the other X-GOVUK documentation sites.